### PR TITLE
Fix example to use log4j 2, drop iPhone ref

### DIFF
--- a/docs/blog/2021-12-09-log4j-zero-day.md
+++ b/docs/blog/2021-12-09-log4j-zero-day.md
@@ -105,7 +105,8 @@ As per [this discussion on HackerNews](https://news.ycombinator.com/item?id=2950
 ### Example Vulnerable Code
 
 ```ts
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.*;
 import java.sql.SQLException;
@@ -113,7 +114,7 @@ import java.util.*;
 
 public class VulnerableLog4jExampleHandler implements HttpHandler {
 
-  static Logger log = Logger.getLogger(log4jExample.class.getName());
+  static Logger log = LogManager.getLogger(log4jExample.class.getName());
 
   /**
    * A simple HTTP endpoint that reads the request's User Agent and logs it back.


### PR DESCRIPTION
pedantry: make the example code actually valid log4j 2 use, not log4j 1.x

also: drop the reference to iPhone name change PoC because it's wrong, it just shows the vulnerability exists on a server operated by Apple

PR #260 was abandoned because the submitter recognized the example was using log4j 1.x syntax, but if that PR hadn't been abandoned it would have saved me time checking that paramaterized usage was vulnerable and submitting PR #270 to make the same change (and I'm not sure 1.x is vulnerable anyway)